### PR TITLE
URL Cleanup

### DIFF
--- a/jpetstore/db/hsqldb/pom-manager.xml
+++ b/jpetstore/db/hsqldb/pom-manager.xml
@@ -1,10 +1,10 @@
 <!-- POM to run manager. 
      Ideally, we won't need a separate pom-manager.xml. However, since the use of two different ids and phase 
-     described at http://article.gmane.org/gmane.comp.java.maven-plugins.mojo.user/1307 doesn't seem to work 
+     described at https://article.gmane.org/gmane.comp.java.maven-plugins.mojo.user/1307 doesn't seem to work 
 	 (the configuration element is ignored), we have to resort to using a separate file. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
-                             http://maven.apache.org/maven-v4_0_0.xsd">
+                             https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.samples.jpetstore</groupId>
 	<artifactId>org.springframework.samples.jpetstore.hsqldb.manager</artifactId>

--- a/jpetstore/db/hsqldb/pom.xml
+++ b/jpetstore/db/hsqldb/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
-                             http://maven.apache.org/maven-v4_0_0.xsd">
+                             https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.samples.jpetstore</groupId>
 	<artifactId>org.springframework.samples.jpetstore.hsqldb.server</artifactId>

--- a/jpetstore/pom.xml
+++ b/jpetstore/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.samples</groupId>
 	<artifactId>jpetstore</artifactId>
@@ -244,7 +244,7 @@
 		<repository>
 			<id>org.springsource.maven.snapshot</id>
 			<name>SpringSource Maven Central-compatible Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<updatePolicy>daily</updatePolicy>
 			</snapshots>
@@ -252,25 +252,25 @@
 		<repository>
 			<id>spring-milestone</id>
 			<name>Spring Maven MILESTONE Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</repository>
 		<repository>
 			<id>standard repo</id>
-			<url>http://repo1.maven.org/maven2</url>
+			<url>https://repo1.maven.org/maven2</url>
 		</repository>
 		<repository>
 			<id>mirror repo</id>
-			<url>http://mirrors.ibiblio.org/pub/mirrors/maven2</url>
+			<url>/maven2</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.release</id>
 			<name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.external</id>
 			<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/external</url>
+			<url>https://repository.springsource.com/maven/bundles/external</url>
 		</repository>
 		<repository>
 			<id>sqlfire-release</id>

--- a/jpetstore/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/jpetstore/src/main/webapp/WEB-INF/applicationContext.xml
@@ -10,9 +10,9 @@
 		xmlns:aop="http://www.springframework.org/schema/aop"
 		xmlns:tx="http://www.springframework.org/schema/tx"
 		xsi:schemaLocation="
-			http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-			http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd
-			http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
+			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+			http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
+			http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
 
 
 	<!-- ========================= GENERAL DEFINITIONS ========================= -->

--- a/jpetstore/src/main/webapp/WEB-INF/dataAccessContext-jta.xml
+++ b/jpetstore/src/main/webapp/WEB-INF/dataAccessContext-jta.xml
@@ -16,8 +16,8 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:jee="http://www.springframework.org/schema/jee"
 		xsi:schemaLocation="
-			http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-			http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee-2.5.xsd">
+			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+			http://www.springframework.org/schema/jee https://www.springframework.org/schema/jee/spring-jee-2.5.xsd">
 
 
 	<!-- ========================= RESOURCE DEFINITIONS ========================= -->

--- a/jpetstore/src/main/webapp/WEB-INF/dataAccessContext-local.xml
+++ b/jpetstore/src/main/webapp/WEB-INF/dataAccessContext-local.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
   - Application context definition for JPetStore's data access layer.

--- a/jpetstore/src/main/webapp/WEB-INF/petstore-servlet.xml
+++ b/jpetstore/src/main/webapp/WEB-INF/petstore-servlet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
   - DispatcherServlet application context for the Spring web MVC

--- a/jpetstore/src/main/webapp/WEB-INF/remoting-servlet.xml
+++ b/jpetstore/src/main/webapp/WEB-INF/remoting-servlet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
   - Dispatcher servlet for HTTP remoting via Hessian, Burlap, and Spring's

--- a/jpetstore/src/main/webapp/WEB-INF/struts-config.xml
+++ b/jpetstore/src/main/webapp/WEB-INF/struts-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!DOCTYPE struts-config PUBLIC
           "-//Apache Software Foundation//DTD Struts Configuration 1.1//EN"
-          "http://jakarta.apache.org/struts/dtds/struts-config_1_1.dtd">
+          "https://jakarta.apache.org/struts/dtds/struts-config_1_1.dtd">
 
 <struts-config>
 

--- a/jpetstore/src/main/webapp/WEB-INF/web.xml
+++ b/jpetstore/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+		xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
 
 	<display-name>Spring JPetStore</display-name>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://dist.gemstone.com/maven/release (404) with 2 occurrences could not be migrated:  
   ([https](https://dist.gemstone.com/maven/release) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://mirrors.ibiblio.org/pub/mirrors/maven2 (301) with 1 occurrences migrated to:  
  /maven2 ([https](https://mirrors.ibiblio.org/pub/mirrors/maven2) result IllegalArgumentException).
* http://article.gmane.org/gmane.comp.java.maven-plugins.mojo.user/1307 (IllegalArgumentException) with 1 occurrences migrated to:  
  https://article.gmane.org/gmane.comp.java.maven-plugins.mojo.user/1307 ([https](https://article.gmane.org/gmane.comp.java.maven-plugins.mojo.user/1307) result IllegalArgumentException).
* http://repository.springsource.com/maven/bundles/external (404) with 1 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/external ([https](https://repository.springsource.com/maven/bundles/external) result 404).
* http://repository.springsource.com/maven/bundles/release (404) with 1 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springframework.org/dtd/spring-beans-2.0.dtd with 3 occurrences migrated to:  
  https://www.springframework.org/dtd/spring-beans-2.0.dtd ([https](https://www.springframework.org/dtd/spring-beans-2.0.dtd) result 200).
* http://www.springframework.org/schema/aop/spring-aop-2.5.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop-2.5.xsd ([https](https://www.springframework.org/schema/aop/spring-aop-2.5.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-2.5.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.5.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.5.xsd) result 200).
* http://www.springframework.org/schema/jee/spring-jee-2.5.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/jee/spring-jee-2.5.xsd ([https](https://www.springframework.org/schema/jee/spring-jee-2.5.xsd) result 200).
* http://www.springframework.org/schema/tx/spring-tx-2.5.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx-2.5.xsd ([https](https://www.springframework.org/schema/tx/spring-tx-2.5.xsd) result 200).
* http://jakarta.apache.org/struts/dtds/struts-config_1_1.dtd with 1 occurrences migrated to:  
  https://jakarta.apache.org/struts/dtds/struts-config_1_1.dtd ([https](https://jakarta.apache.org/struts/dtds/struts-config_1_1.dtd) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd ([https](https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd) result 302).
* http://maven.springframework.org/milestone with 1 occurrences migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/snapshot with 1 occurrences migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* http://repo1.maven.org/maven2 with 1 occurrences migrated to:  
  https://repo1.maven.org/maven2 ([https](https://repo1.maven.org/maven2) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/xml/ns/j2ee with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.springframework.org/schema/aop with 2 occurrences
* http://www.springframework.org/schema/beans with 4 occurrences
* http://www.springframework.org/schema/jee with 2 occurrences
* http://www.springframework.org/schema/tx with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 6 occurrences