### PR TITLE
URL Cleanup

### DIFF
--- a/jpetstore/readme.txt
+++ b/jpetstore/readme.txt
@@ -48,14 +48,14 @@ steps (these assume Tomcat 7 and JDK 6 are used):
 requires JDK 6.0 or later. The JDK 'bin' directory should be included in your PATH. 
 The JAVA_HOME environment variable should point to the JDK installation directory. 
 The JDK can be downloaded from: 
-http://www.oracle.com/technetwork/java/javase/downloads/index.html
+https://www.oracle.com/technetwork/java/javase/downloads/index.html
 
 - If not already installed, download and install Tomcat 7.0.xx. The steps outlined 
 below were based on testing on Windows XP SP3. I recommend installing the Windows 
 service and control the start/stop commands through the Tomcat Windows service.
 
 - If not already installed, download and install SQLFire 
-(http://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire?view=overview).
+(https://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire?view=overview).
 
 - If not already installed, download and install Maven (with version >= 2.0.8). 
 Also, add [Maven_dir]\bin to the PATH environment variable.

--- a/jpetstore/src/main/webapp/WEB-INF/jsp/spring/IncludeBottom.jsp
+++ b/jpetstore/src/main/webapp/WEB-INF/jsp/spring/IncludeBottom.jsp
@@ -3,7 +3,7 @@
 <table align="center">
   <tr>
 	  <td>
-			<a href="http://www.springframework.org">
+			<a href="https://www.springframework.org">
 				<img border="0" align="center" src="../images/poweredBySpring.gif" alt="Powered by the Spring Framework"/>
 			</a>
 		</td>
@@ -11,7 +11,7 @@
 			<a href="http://www.querydsl.com">Powered by QueryDSL</a>
 		</td>
 		<td>
-			<a href="http://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire">Powered by SQLFire</a>
+			<a href="https://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire">Powered by SQLFire</a>
 		</td>
 	</tr>
 </table>

--- a/jpetstore/src/main/webapp/WEB-INF/jsp/struts/IncludeBottom.jsp
+++ b/jpetstore/src/main/webapp/WEB-INF/jsp/struts/IncludeBottom.jsp
@@ -3,7 +3,7 @@
 <table align="center">
   <tr>
 	  <td>
-			<a href="http://www.springframework.org">
+			<a href="https://www.springframework.org">
 				<img border="0" align="center" src="../images/poweredBySpring.gif" alt="Powered by the Spring Framework"/>
 			</a>
 		</td>
@@ -11,7 +11,7 @@
 			<a href="http://www.querydsl.com">Powered by QueryDSL</a>
 		</td>
 		<td>
-			<a href="http://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire">Powered by SQLFire</a>
+			<a href="https://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire">Powered by SQLFire</a>
 		</td>
 	</tr>
 </table>

--- a/jpetstore/src/main/webapp/WEB-INF/server-config.wsdd
+++ b/jpetstore/src/main/webapp/WEB-INF/server-config.wsdd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<deployment xmlns="http://xml.apache.org/axis/wsdd/" xmlns:java="http://xml.apache.org/axis/wsdd/providers/java">
+<deployment xmlns="https://xml.apache.org/axis/wsdd/" xmlns:java="https://xml.apache.org/axis/wsdd/providers/java">
 	<globalConfiguration>
 		<parameter name="adminPassword" value="admin"/>
 		<parameter name="sendXsiTypes" value="true"/>
@@ -23,7 +23,7 @@
 		<parameter name="allowedMethods" value="AdminService"/>
 		<parameter name="enableRemoteAdmin" value="false"/>
 		<parameter name="className" value="org.apache.axis.utils.Admin"/>
-		<namespace>http://xml.apache.org/axis/wsdd/</namespace>
+		<namespace>https://xml.apache.org/axis/wsdd/</namespace>
 	</service>
 	<service name="OrderService" provider="java:RPC">
 		<parameter name="allowedMethods" value="*"/>

--- a/jpetstore/src/main/webapp/index.html
+++ b/jpetstore/src/main/webapp/index.html
@@ -57,7 +57,7 @@
 <table align="center">
   <tr>
 	  <td>
-			<a href="http://www.springframework.org">
+			<a href="https://www.springframework.org">
 				<img border="0" align="center" src="images/poweredBySpring.gif" alt="Powered by the Spring Framework"/>
 			</a>
 		</td>
@@ -65,7 +65,7 @@
 			<a href="http://www.querydsl.com">Powered by QueryDSL</a>
 		</td>
 		<td>
-			<a href="http://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire">Powered by SQLFire</a>
+			<a href="https://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire">Powered by SQLFire</a>
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://www.querydsl.com (200) with 3 occurrences could not be migrated:  
   ([https](https://www.querydsl.com) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire (301) with 3 occurrences migrated to:  
  https://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire ([https](https://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire) result 404).
* [ ] http://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire?view=overview (301) with 1 occurrences migrated to:  
  https://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire?view=overview ([https](https://communities.vmware.com/community/vmtn/appplatform/vfabric_sqlfire?view=overview) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.oracle.com/technetwork/java/javase/downloads/index.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/index.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/index.html) result 200).
* [ ] http://www.springframework.org with 3 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://xml.apache.org/axis/wsdd/ with 2 occurrences migrated to:  
  https://xml.apache.org/axis/wsdd/ ([https](https://xml.apache.org/axis/wsdd/) result 302).
* [ ] http://xml.apache.org/axis/wsdd/providers/java with 1 occurrences migrated to:  
  https://xml.apache.org/axis/wsdd/providers/java ([https](https://xml.apache.org/axis/wsdd/providers/java) result 302).

# Ignored
These URLs were intentionally ignored.

* http://jakarta.apache.org/struts/tags-html with 4 occurrences
* http://java.sun.com/jsp/jstl/core with 2 occurrences
* http://java.sun.com/jsp/jstl/fmt with 2 occurrences
* http://localhost:8080/jpetstore-1.0.0-SNAPSHOT with 1 occurrences
* http://www.springframework.org/tags with 3 occurrences